### PR TITLE
Adapt def _assign_imports_to_globals

### DIFF
--- a/src/pyforest/user_specific_imports.py
+++ b/src/pyforest/user_specific_imports.py
@@ -59,8 +59,24 @@ def _get_imports_from_user_settings(user_imports_path) -> list:
     return _get_imports(file_lines)
 
 
-def _assign_imports_to_globals(import_statements: list, globals_) -> None:
-    symbols = [import_statement.split()[-1] for import_statement in import_statements]
+def _assign_imports_to_globals(import_statements: list) -> None:
+    symbols = []; new_import_statements = []
+    
+    for import_statement in import_statements:
+        def process(statement):
+            symbols.append(statement.split()[-1])
+            new_import_statements.append(statement)
+
+        if "," not in import_statement:
+            process(import_statement)
+        else:
+            multi_import_statement = import_statement.split(",")
+            splited_statement = multi_import_statement[0].split()
+            for i in range(len(multi_import_statement)):
+                if not i: process(multi_import_statement[0])
+                else:
+                    new_statement = splited_statement[:-1] + [multi_import_statement[i]]
+                    process(" ".join(new_statement))
 
     for symbol, import_statement in zip(symbols, import_statements):
         exec(f"{symbol} = LazyImport('{import_statement}')", globals_)

--- a/src/pyforest/user_specific_imports.py
+++ b/src/pyforest/user_specific_imports.py
@@ -72,11 +72,10 @@ def _assign_imports_to_globals(import_statements: list, globals_) -> None:
         else:
             multi_import_statement = import_statement.split(",")
             splited_statement = multi_import_statement[0].split()
-            for i in range(len(multi_import_statement)):
-                if not i: process(multi_import_statement[0])
-                else:
-                    new_statement = splited_statement[:-1] + [multi_import_statement[i]]
-                    process(" ".join(new_statement))
+            process(multi_import_statement[0])
+            for i in range(1, len(multi_import_statement)):
+                new_statement = splited_statement[:-1] + [multi_import_statement[i]]
+                process(" ".join(new_statement))
 
     for symbol, import_statement in zip(symbols, new_import_statements):
         exec(f"{symbol} = LazyImport('{import_statement}')", globals_)

--- a/src/pyforest/user_specific_imports.py
+++ b/src/pyforest/user_specific_imports.py
@@ -59,7 +59,7 @@ def _get_imports_from_user_settings(user_imports_path) -> list:
     return _get_imports(file_lines)
 
 
-def _assign_imports_to_globals(import_statements: list) -> None:
+def _assign_imports_to_globals(import_statements: list, globals_) -> None:
     symbols = []; new_import_statements = []
     
     for import_statement in import_statements:
@@ -78,7 +78,7 @@ def _assign_imports_to_globals(import_statements: list) -> None:
                     new_statement = splited_statement[:-1] + [multi_import_statement[i]]
                     process(" ".join(new_statement))
 
-    for symbol, import_statement in zip(symbols, import_statements):
+    for symbol, import_statement in zip(symbols, new_import_statements):
         exec(f"{symbol} = LazyImport('{import_statement}')", globals_)
 
 


### PR DESCRIPTION
Hi~

I found we often make multiple imports in one line like below
from keras.layers import LSTM, Dropout, Dense.

Therefore, I rewrote the func., def _assign_imports_to_globals() to make this work.
If you are free, please check it out. 