### PR TITLE
Added disable_javascript_update

### DIFF
--- a/src/pyforest/__init__.py
+++ b/src/pyforest/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from ._imports import *
+from ._importable import disable_javascript_update
 from .utils import (
     get_user_symbols,
     install_extensions,
@@ -14,7 +15,6 @@ for import_symbol in pyforest_imports:
     # don't overwrite symbols of the user
     if import_symbol not in user_symbols.keys():
         user_symbols[import_symbol] = eval(import_symbol)
-
 
 #  set __version__ attribute
 from pkg_resources import get_distribution, DistributionNotFound

--- a/src/pyforest/_importable.py
+++ b/src/pyforest/_importable.py
@@ -91,6 +91,15 @@ class LazyImport(object):
             return f"lazy pyforest.LazyImport for '{self.__import_statement__}'"
 
 
+def disable_javascript_update():
+    """
+    For use in non-Jupyter environments, disable _update_import_cell
+    """
+    from pyforest import _importable
+    _importable._update_import_cell_disabled = _importable._update_import_cell
+    _importable._update_import_cell = lambda: None
+
+
 def _update_import_cell():
     try:
         from IPython.display import display, Javascript


### PR DESCRIPTION
Added disable_javascript_update to prevent lazy imports from polluting non-jupyter consoles with "<IPython.core.display.Javascript object>". Addresses issue #30.